### PR TITLE
Add option to supply Crypto object directly

### DIFF
--- a/as4-client/src/main/java/dk/toldst/eutk/as4client/builder/interfaces/As4SetCrypto.java
+++ b/as4-client/src/main/java/dk/toldst/eutk/as4client/builder/interfaces/As4SetCrypto.java
@@ -1,7 +1,10 @@
 package dk.toldst.eutk.as4client.builder.interfaces;
 
+import java.util.Properties;
+
+import org.apache.wss4j.common.crypto.Merlin;
+
 import dk.toldst.eutk.as4client.exceptions.AS4Exception;
-import org.apache.wss4j.common.crypto.Crypto;
 
 public interface As4SetCrypto {
     /**
@@ -11,5 +14,13 @@ public interface As4SetCrypto {
      * @throws AS4Exception if the file is not currectly read, or a Crypto object cannot be built.
      */
     As4SetPasswordTokenDetails setCrypto(String filepath) throws AS4Exception;
-    //As4SetPasswordTokenDetails setCrypto(Crypto cryptoProps);
+
+    /**
+     * Sets the Crypto object.
+     * @param crypto a crypto object containing Keystore/Truststore, which mist be of type "Merlin"
+     * @param crypto the cryptoProperties, describing how the Keystore returned by the crypto object should be handled
+     * @return a As4SetPasswordTokenDetails object, which is used to continue the builder pattern and set the password for the crypto.
+     * @throws AS4Exception if the crypto object is invalid (for example: does not contain any certificates)
+     */
+    As4SetPasswordTokenDetails setCrypto(Merlin crypto, Properties cryptoProperties) throws AS4Exception;
 }


### PR DESCRIPTION
We would like to supply Crypto parameters directly instead of having to place a file on the system.

I saw the method in the `As4SetCrypto` interface so my guess was that the functionality was intended anyways.
I sadly can not test the change at the moment because I'm missing the certificates and did not find anything in the `test` folder.